### PR TITLE
Add DestroyTransform rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ rules:
     mask_char: "*"
 ```
 
+#### Destroy (replace with a fixed value)
+> The destroy name is inspired from [postgresql_anonymizer](https://postgresql-anonymizer.readthedocs.io/en/stable/masking_functions/#destruction)
+```yaml
+rules:
+  - column: email
+    method: destroy
+    replace_with: "SOME VALUE" # Optional, default is "CONFIDENTIAL"
+
+
 ## Contributing
 
 - :fork_and_knife: Fork the repository

--- a/anonymize/models/outputs.py
+++ b/anonymize/models/outputs.py
@@ -13,7 +13,7 @@ class AbstractDataOutput(ABC):
 
 
 class CSVOutput(BaseModel, AbstractDataOutput):
-    type: Literal["csv"]
+    type: Literal["csv"] = "csv"
     path: str
     separator: str = ","
 

--- a/anonymize/models/rules.py
+++ b/anonymize/models/rules.py
@@ -129,4 +129,16 @@ class MaskLeftTransform(BaseModel):
         coerce_numbers_to_str = True
 
 
-Rule = Union[HashTransform, FakeTransform, MaskRightTransform, MaskLeftTransform]
+class DestroyTransform(BaseModel):
+    column: str
+    method: Literal["destroy"] = "destroy"
+    replace_with: str = "CONFIDENTIAL"
+
+    def apply(self, data: pl.LazyFrame) -> pl.LazyFrame:
+        logger.info(
+            f"Applying destroy transformation on column {self.column} with replacement {self.replace_with}"
+        )
+        return data.with_columns(pl.lit(self.replace_with).alias(self.column))
+
+
+Rule = Union[HashTransform, FakeTransform, MaskRightTransform, MaskLeftTransform, DestroyTransform]

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,10 +2,7 @@ from anonymize.models.rules import FakeTransform, HashTransform
 import pytest
 from contextlib import nullcontext as does_not_raise
 import polars as pl
-from anonymize.models.rules import (
-    MaskRightTransform,
-    MaskLeftTransform,
-)
+from anonymize.models.rules import MaskRightTransform, MaskLeftTransform, DestroyTransform
 from .conftest import compare_dataframes
 
 
@@ -79,3 +76,12 @@ def test_fake_transform_email():
     actual = FakeTransform(column="mail", faker_type="email").apply(df)
 
     assert set(actual["mail"].str.contains("@").to_list()) == {True}
+
+
+def test_destroy_transform():
+    df = pl.DataFrame({"name": ["John", "Doe", "Alice"]})
+    actual = DestroyTransform(column="name", replace_with="hidden data").apply(df)
+
+    expected = pl.DataFrame({"name": ["hidden data", "hidden data", "hidden data"]})
+
+    compare_dataframes(actual, expected)


### PR DESCRIPTION
The `DestroyTransform` replaces the **entire** column with a fixed value (default value is: `"CONFIDENTIAL"`)