### PR TITLE
Add types casting warnings

### DIFF
--- a/anonymize/__main__.py
+++ b/anonymize/__main__.py
@@ -12,6 +12,7 @@ def main(config: Config):
             if rule.column not in data.columns:
                 logger.warning(f"Column {rule.column} not found in the dataset. Skipping.")
                 continue
+            # TODO: Add keep_type param, run the rule only if the column type is compatible
             data = rule.apply(data)
         dfs.append(data)
 


### PR DESCRIPTION
For some rules, show a warning if the output data type mismatches the input data type (example: masking a numerical column)